### PR TITLE
API: make edugain export tag name configurable

### DIFF
--- a/app/controllers/api/raw_entity_descriptors_controller.rb
+++ b/app/controllers/api/raw_entity_descriptors_controller.rb
@@ -4,6 +4,8 @@ module API
   class RawEntityDescriptorsController < APIController
     include SetSAMLTypeFromXML
 
+    DEFAULT_EDUGAIN_EXPORT_TAG_NAME = 'aaf-edugain-export'
+
     before_action do
       @entity_source = EntitySource[source_tag: params[:tag]]
       raise(ResourceNotFound) if @entity_source.nil?
@@ -71,10 +73,15 @@ module API
       known_entity.tag_as(params[:tag])
 
       if patch_params[:edugain_enabled]
-        known_entity.tag_as('aaf-edugain-export')
+        known_entity.tag_as(edugain_export_tag)
       else
-        known_entity.untag_as('aaf-edugain-export')
+        known_entity.untag_as(edugain_export_tag)
       end
+    end
+
+    def edugain_export_tag
+      Rails.application.config.saml_service.api.edugain_export_tag_name ||
+        DEFAULT_EDUGAIN_EXPORT_TAG_NAME
     end
 
     def patch_params

--- a/app/controllers/api/raw_entity_descriptors_controller.rb
+++ b/app/controllers/api/raw_entity_descriptors_controller.rb
@@ -80,7 +80,7 @@ module API
     end
 
     def edugain_export_tag
-      Rails.application.config.saml_service.api.edugain_export_tag_name ||
+      Rails.application.config.saml_service&.api&.edugain_export_tag_name ||
         DEFAULT_EDUGAIN_EXPORT_TAG_NAME
     end
 

--- a/config/saml_service.yml.dist
+++ b/config/saml_service.yml.dist
@@ -1,6 +1,8 @@
 defaults: &defaults
   metadata:
     negative_cache_ttl: 600
+  api:
+    edugain_export_tag_name: 'aaf-edugain-export'
 
 development:
   <<: *defaults


### PR DESCRIPTION
In the PATCH API, when `edugain_enabled` is True, the API tags the entity with
hard-coded tag 'aaf-edugain-export'.

This name is specific to AAF.

Make the tag name configurable, with default being the current value.

Add template matching the current value to config/saml_service.yml.dist

Tested locally.  All rspec tests pass.

Declined by AAF in ausaccessfed#213 as not relevant for them, so merging locally.