### PR TITLE
App: add health check URL

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,14 +10,19 @@ class ApplicationController < ActionController::Base
   rescue_from Unauthorized, with: :unauthorized
 
   protect_from_forgery with: :exception
-  before_action :ensure_authenticated
-  after_action :ensure_access_checked
+  before_action :ensure_authenticated, except: :health
+  after_action :ensure_access_checked, except: :health
 
   def subject
     subject = session[:subject_id] && Subject[session[:subject_id]]
     return nil unless subject.try(:functioning?)
 
     @subject = subject
+  end
+
+  def health
+    Redis.new.ping && Sequel::Model.db.test_connection
+    render body: 'ok'
   end
 
   protected

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,10 @@ Rails.application.routes.draw do
           constraints: { identifier: /.*/ }, via: :all
   end
 
+  match '/health',
+        to: 'application#health',
+        via: :all
+
   namespace :api, defaults: { format: 'json' } do
     scope constraints: APIConstraints.new(version: 1, default: true) do
       scope 'discovery' do

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -9,4 +9,15 @@ RSpec.describe ApplicationController, type: :controller do
   # currently using Sequel instead of ActiveRecord, but Lipstick requires the
   # latter, so that's not an option at this juncture.
   # include_examples 'Application controller'
+
+  describe 'health' do
+    def run
+      get 'health'
+    end
+
+    it 'responds with status code 200' do
+      run
+      expect(response.body).to include('ok')
+    end
+  end
 end


### PR DESCRIPTION
To assist with monitoring.

Check redis and DB connection and return 200 OK if both succeed, otherwise fail.

Declined by AAF in ausaccessfed#215 as not relevant for them, so merging locally.