### PR TITLE
new: sync_to_git: include removed entityID in commit message (extracting it from filename)

### DIFF
--- a/bin/sync_to_git_repository.rb
+++ b/bin/sync_to_git_repository.rb
@@ -114,8 +114,8 @@ class SyncToGitRepository
       decoded = nil
     end
 
-    # Accept decoded value only if it consists of sane URI characters - avoid runaway Base64 ddata
-    decoded && %r{^[-+_.:/A-Za-z0-9]+$}.match(decoded) ? decoded : 'stale entity'
+    # Accept decoded value only if it consists of sane URI characters - avoid runaway Base64 data - and limit length to 255 chars
+    decoded && %r{^[-+_.:/A-Za-z0-9]{1,255}$}.match(decoded) ? decoded : 'stale entity'
   end
 
   def remove_stale(path)

--- a/bin/sync_to_git_repository.rb
+++ b/bin/sync_to_git_repository.rb
@@ -115,7 +115,7 @@ class SyncToGitRepository
     end
 
     # Accept decoded value only if it consists of sane URI characters - avoid runaway Base64 ddata
-    decoded && %r{^[-+_.:/A-Za-z0-9$]+}.match(decoded) ? decoded : 'stale entity'
+    decoded && %r{^[-+_.:/A-Za-z0-9]+$}.match(decoded) ? decoded : 'stale entity'
   end
 
   def remove_stale(path)

--- a/spec/bin/sync_to_git_repository_spec.rb
+++ b/spec/bin/sync_to_git_repository_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe SyncToGitRepository do
           expect(commit_spy).to have_received(:create)
             .with(repo,
                   author: author, committer: author, tree: new_tree,
-                  message: '[sync] remove stale entity', parents: [head_commit],
+                  message: "[sync] remove #{stale_entity_id}", parents: [head_commit],
                   update_ref: 'HEAD')
         end
       end
@@ -181,7 +181,9 @@ RSpec.describe SyncToGitRepository do
       end
 
       context 'for a removed entity' do
-        let(:stale) { "entities/#{md_instance.identifier}-stale-entity.xml" }
+        let(:stale_entity_id) { "#{Faker::Internet.url}/shibboleth" }
+        let(:stale_entity_id_encoded) { Base64.urlsafe_encode64(stale_entity_id).delete('=') }
+        let(:stale) { "entities/#{md_instance.identifier}-#{stale_entity_id_encoded}.xml" }
 
         before do
           allow(index).to receive(:map).and_return([stale])


### PR DESCRIPTION
Rely on filenames being created with:

    encoded_entity_id = Base64.urlsafe_encode64(ke.entity_id).delete('=')
    filename = "entities/#{@md_instance.identifier}-#{encoded_entity_id}.xml"

... and revert the process to get back the entityID.

If anything goes wrong, revert back to 'stale entity'

Adjust tests accordingly.