### PR TITLE
Refactor hardcoded AAF tags into `EdugainHelper`

### DIFF
--- a/app/controllers/api/raw_entity_descriptors_controller.rb
+++ b/app/controllers/api/raw_entity_descriptors_controller.rb
@@ -71,9 +71,9 @@ module API
       known_entity.tag_as(params[:tag])
 
       if patch_params[:edugain_enabled]
-        known_entity.tag_as(EdugainHelper::edugain_export_tag)
+        known_entity.tag_as(EdugainHelper.edugain_export_tag)
       else
-        known_entity.untag_as(EdugainHelper::edugain_export_tag)
+        known_entity.untag_as(EdugainHelper.edugain_export_tag)
       end
     end
 

--- a/app/controllers/api/raw_entity_descriptors_controller.rb
+++ b/app/controllers/api/raw_entity_descriptors_controller.rb
@@ -4,8 +4,6 @@ module API
   class RawEntityDescriptorsController < APIController
     include SetSAMLTypeFromXML
 
-    DEFAULT_EDUGAIN_EXPORT_TAG_NAME = 'aaf-edugain-export'
-
     before_action do
       @entity_source = EntitySource[source_tag: params[:tag]]
       raise(ResourceNotFound) if @entity_source.nil?
@@ -73,15 +71,10 @@ module API
       known_entity.tag_as(params[:tag])
 
       if patch_params[:edugain_enabled]
-        known_entity.tag_as(edugain_export_tag)
+        known_entity.tag_as(EdugainHelper::edugain_export_tag)
       else
-        known_entity.untag_as(edugain_export_tag)
+        known_entity.untag_as(EdugainHelper::edugain_export_tag)
       end
-    end
-
-    def edugain_export_tag
-      Rails.application.config.saml_service&.api&.edugain_export_tag_name ||
-        DEFAULT_EDUGAIN_EXPORT_TAG_NAME
     end
 
     def patch_params

--- a/app/helpers/edugain_helper.rb
+++ b/app/helpers/edugain_helper.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 module EdugainHelper
-    DEFAULT_EDUGAIN_EXPORT_TAG_NAME = 'aaf-edugain-export'
-    DEFAULT_EDUGAIN_VERIFIED_TAG_NAME = 'aaf-edugain-verified'
+  DEFAULT_EDUGAIN_EXPORT_TAG_NAME = 'aaf-edugain-export'
+  DEFAULT_EDUGAIN_VERIFIED_TAG_NAME = 'aaf-edugain-verified'
 
-    def EdugainHelper.edugain_export_tag
-      Rails.application.config.saml_service&.api&.edugain_export_tag_name ||
-        DEFAULT_EDUGAIN_EXPORT_TAG_NAME
-    end
+  def self.edugain_export_tag
+    Rails.application.config.saml_service&.api&.edugain_export_tag_name ||
+      DEFAULT_EDUGAIN_EXPORT_TAG_NAME
+  end
 
-    def EdugainHelper.edugain_verified_tag
-      Rails.application.config.saml_service&.api&.edugain_verified_tag_name ||
-        DEFAULT_EDUGAIN_VERIFIED_TAG_NAME
-    end
+  def self.edugain_verified_tag
+    Rails.application.config.saml_service&.api&.edugain_verified_tag_name ||
+      DEFAULT_EDUGAIN_VERIFIED_TAG_NAME
+  end
 end

--- a/app/helpers/edugain_helper.rb
+++ b/app/helpers/edugain_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module EdugainHelper
+    DEFAULT_EDUGAIN_EXPORT_TAG_NAME = 'aaf-edugain-export'
+    DEFAULT_EDUGAIN_VERIFIED_TAG_NAME = 'aaf-edugain-verified'
+
+    def EdugainHelper.edugain_export_tag
+      Rails.application.config.saml_service&.api&.edugain_export_tag_name ||
+        DEFAULT_EDUGAIN_EXPORT_TAG_NAME
+    end
+
+    def EdugainHelper.edugain_verified_tag
+      Rails.application.config.saml_service&.api&.edugain_verified_tag_name ||
+        DEFAULT_EDUGAIN_VERIFIED_TAG_NAME
+    end
+end

--- a/app/models/edugain/abstract_entity_export.rb
+++ b/app/models/edugain/abstract_entity_export.rb
@@ -11,7 +11,7 @@ module Edugain
     def save
       add_research_and_scholarship
       add_sirtfi
-      entity_descriptor.known_entity.tag_as 'aaf-edugain-export'
+      entity_descriptor.known_entity.tag_as EdugainHelper::edugain_export_tag
       entity_descriptor.known_entity.touch
       entity_descriptor.save raise_on_save_failure: true
     end

--- a/app/models/edugain/abstract_entity_export.rb
+++ b/app/models/edugain/abstract_entity_export.rb
@@ -11,7 +11,7 @@ module Edugain
     def save
       add_research_and_scholarship
       add_sirtfi
-      entity_descriptor.known_entity.tag_as EdugainHelper::edugain_export_tag
+      entity_descriptor.known_entity.tag_as EdugainHelper.edugain_export_tag
       entity_descriptor.known_entity.touch
       entity_descriptor.save raise_on_save_failure: true
     end

--- a/app/models/edugain/non_research_and_scholarship_entity.rb
+++ b/app/models/edugain/non_research_and_scholarship_entity.rb
@@ -9,7 +9,7 @@ module Edugain
     end
 
     def approve
-      descriptor.known_entity.tag_as 'aaf-edugain-verified'
+      descriptor.known_entity.tag_as EdugainHelper::edugain_verified_tag
       descriptor.known_entity.touch
       descriptor.save(raise_on_save_failure: true)
     end

--- a/app/models/edugain/non_research_and_scholarship_entity.rb
+++ b/app/models/edugain/non_research_and_scholarship_entity.rb
@@ -9,7 +9,7 @@ module Edugain
     end
 
     def approve
-      descriptor.known_entity.tag_as EdugainHelper::edugain_verified_tag
+      descriptor.known_entity.tag_as EdugainHelper.edugain_verified_tag
       descriptor.known_entity.touch
       descriptor.save(raise_on_save_failure: true)
     end

--- a/config/saml_service.yml.dist
+++ b/config/saml_service.yml.dist
@@ -4,6 +4,7 @@ defaults: &defaults
   api:
     authentication: :token
     edugain_export_tag_name: 'aaf-edugain-export'
+    edugain_verified_tag_name: 'aaf-edugain-verified'
 
 development:
   <<: *defaults


### PR DESCRIPTION
Refactors the 'aaf-edugain-export' and 'aaf-edugain-verified' tags into
configurable values accessed via a new `EdugainHelper` module.