### PR TITLE
fix: UpdFromFR: sync org changes for existing descriptors

### DIFF
--- a/app/jobs/concerns/etl/attribute_authorities.rb
+++ b/app/jobs/concerns/etl/attribute_authorities.rb
@@ -15,7 +15,7 @@ module Etl
     def create_or_update_aa(ed, ds, aa_data)
       attrs = aa_attrs(aa_data)
       aa = create_or_update_by_fr_id(ds, aa_data[:id], attrs) do |obj|
-        obj.entity_descriptor = ed
+        obj.entity_descriptor = ed unless obj.id # only when creating
         obj.organization = ed.organization
         add_aa_tag(ed)
       end

--- a/app/jobs/concerns/etl/entity_descriptors.rb
+++ b/app/jobs/concerns/etl/entity_descriptors.rb
@@ -33,7 +33,7 @@ module Etl
     def create_or_update_ed_from_fr(o, ds, ed_data)
       create_or_update_by_fr_id(ds, ed_data[:id], ed_attrs(ed_data)) do |ed|
         ed.organization = o
-        ed.known_entity = known_entity(ed_data)
+        ed.known_entity = known_entity(ed_data) unless ed.id # only when creating
         ed.known_entity.tag_as(@source.source_tag)
       end
     end

--- a/app/jobs/concerns/etl/identity_providers.rb
+++ b/app/jobs/concerns/etl/identity_providers.rb
@@ -22,7 +22,7 @@ module Etl
     def create_or_update_idp(ed, ds, idp_data)
       attrs = idp_attrs(idp_data)
       idp = create_or_update_by_fr_id(ds, idp_data[:id], attrs) do |obj|
-        obj.entity_descriptor = ed
+        obj.entity_descriptor = ed unless obj.id # only when creating
         obj.organization = ed.organization
         ed.known_entity.tag_as(Tag::IDP)
       end

--- a/app/jobs/concerns/etl/service_providers.rb
+++ b/app/jobs/concerns/etl/service_providers.rb
@@ -17,7 +17,7 @@ module Etl
     def create_or_update_sp(ed, ds, sp_data)
       attrs = sp_attrs(sp_data)
       sp = create_or_update_by_fr_id(ds, sp_data[:id], attrs) do |obj|
-        obj.entity_descriptor = ed
+        obj.entity_descriptor = ed unless obj.id # only when creating
         obj.organization = ed.organization
         ed.known_entity.tag_as(Tag::SP)
       end

--- a/app/jobs/concerns/store_federation_registry_data.rb
+++ b/app/jobs/concerns/store_federation_registry_data.rb
@@ -2,7 +2,7 @@
 
 module StoreFederationRegistryData
   def create_or_update_by_fr_id(dataset, fr_id, attrs)
-    update_by_fr_id(dataset, fr_id, attrs) ||
+    update_by_fr_id(dataset, fr_id, attrs) { |o| yield o if block_given? } ||
       create_by_fr_id(dataset, fr_id, attrs) { |o| yield o if block_given? }
   end
 
@@ -21,6 +21,12 @@ module StoreFederationRegistryData
   def update_by_fr_id(dataset, fr_id, attrs)
     obj = FederationRegistryObject.local_instance(fr_id, dataset)
     obj.try(:update, attrs)
+    yield obj if obj && block_given?
+    # explicitly save changes (and use safe navigation in case obj is nil)
+    # but not in test env, as some test cases do not validate (and cannot be saved)
+    # :nocov:
+    obj&.save unless Rails.env.test?
+    # :nocov:
     obj
   end
 


### PR DESCRIPTION
Organisation for any Descriptor (Entity, IdPSSO, SPSSO, AttrAuth) was only getting set when creating the descriptor, not when updating.

Consequently, if an EntityDescriptor was moved to a different organisation in FR, this change wasn't getting picked in SAML Service and was not propagated into metadata.

The organisation is set from within a code block passed to `create_or_update_by_fr_id`, but the block is only used in `create_by_fr_id`, not `update_by_fr_id`.

Pass the block also to `update_by_fr_id` and invoke it if an update is happening (object was found).

As the code blocks is now getting invoked for both create and update, add a guard to certain lines that only should be invoked at create time. The guard condition relies on newly created objects not having an `id` assigned yet.

Explicitly save the object after being updated (required, otherwise changes get discarded).

Avoid invoking the save in `test` mode, as some tests set up test objects that do not validate and cannot be saved.