### PR TITLE
Fix AttributeAuthority constraints

### DIFF
--- a/app/jobs/concerns/etl/attribute_authorities.rb
+++ b/app/jobs/concerns/etl/attribute_authorities.rb
@@ -14,12 +14,16 @@ module Etl
 
     def create_or_update_aa(ed, ds, aa_data)
       attrs = aa_attrs(aa_data)
-      aa = create_or_update_by_fr_id(ds, aa_data[:id], attrs) do |obj|
+      create_or_update_by_fr_id(ds, aa_data[:id], attrs) do |obj|
         obj.entity_descriptor = ed unless obj.id # only when creating
         obj.organization = ed.organization
         add_aa_tag(ed)
+        # WORKAROUND: delayed save won't work for creating relationships
+        # For newly created objects, save them early now to get an ID created
+        # BUT do not save always, as some validations need the objects created below to pass.
+        obj.save if obj.new?
+        aa_saml_core(obj, aa_data)
       end
-      aa_saml_core(aa, aa_data)
     end
 
     def aa_attrs(aa_data)

--- a/app/jobs/concerns/store_federation_registry_data.rb
+++ b/app/jobs/concerns/store_federation_registry_data.rb
@@ -20,12 +20,15 @@ module StoreFederationRegistryData
 
   def update_by_fr_id(dataset, fr_id, attrs)
     obj = FederationRegistryObject.local_instance(fr_id, dataset)
-    obj.try(:update, attrs)
+    # Avoid saving early, as validationa would fail
+    obj.try(:set, attrs)
     yield obj if obj && block_given?
     # explicitly save changes (and use safe navigation in case obj is nil)
     # but not in test env, as some test cases do not validate (and cannot be saved)
+    # however, even in test, still save if obj&.modified holds to compensate for set insted of update above
+    # TODO: fix test setup to be able to always save when running tests
     # :nocov:
-    obj&.save unless Rails.env.test?
+    obj&.save unless Rails.env.test? && !obj&.modified?
     # :nocov:
     obj
   end

--- a/app/models/attribute_authority_descriptor.rb
+++ b/app/models/attribute_authority_descriptor.rb
@@ -15,7 +15,7 @@ class AttributeAuthorityDescriptor < RoleDescriptor
 
   def validate
     super
-    validates_presence :attribute_services, allow_missing: new?
+    validates_presence :attribute_services, allow_missing: new? || !enabled
   end
 
   def assertion_id_request_services?

--- a/spec/support/jobs/concerns/etl/attribute_authorities.rb
+++ b/spec/support/jobs/concerns/etl/attribute_authorities.rb
@@ -266,6 +266,7 @@ RSpec.shared_examples 'ETL::AttributeAuthorities' do
         attribute_authorities_instances.map do |aa|
           json = create_aa_json(identity_provider_instances.first, aa, true)
           json[:saml][:attribute_services].each { |service| service[:functioning] = false }
+          json[:functioning] = false
           json
         end
       end


### PR DESCRIPTION
This is a follow-up to #27 - which triggered some validation issues in the model.

The changes in #27 (adding an extra save) have triggered issues with inactive AttributeAuthority objects that have no AttributeService objects - even without any change to these objects, the sync run was failing.

Further, the model constraints (only allowing an AttributeAuthority descriptor to not have an AttributeService on the first save of a new object, essentially a workaround) did not allow updating an inactive AA to active - this was already broken independent of changes in #27, we just never ran into it.

Solve this by:
* changing AttributeAuthority model constraints to allow inactive AA to have no AttributeService
* re-arranging object creation and saves to only save (and trigger validations) after all parts of the descriptor (incl. the AttributeService endpoints are created)
* fix test setup for a failing test: mark an inactive AA actually inactive

As a number of other tests still cannot handle the explicit saves, the `unless` condition for doing the save is used as a workaround - and looks rather ugly.

Ideally, it would be an unconditional save.  Outside tests, the `save` is always invoked.  For tests, it navigates between tests that would break if saving and tests that would break if not saving.  (It still saves for tests where a save would have been invoked in the `update` call, now replaced with an non-saving `set`).

While the proper approach would be to fix the tests (if they are indeed broken), given that the app has only a few months left before we get rid of it, I leave it with this workaround.